### PR TITLE
Larger recv buffer for ex_abci server

### DIFF
--- a/lib/forge_sdk/util/app.ex
+++ b/lib/forge_sdk/util/app.ex
@@ -29,7 +29,7 @@ defmodule ForgeSdk.Util.App do
   def set_ranch_port(port, app) do
     Application.put_env(app, :ranch_opts, %{
       max_connections: 3,
-      socket_opts: [port: port, buffer: 655_350, sndbuf: 65_535, recbuf: 655_350]
+      socket_opts: [port: port, buffer: 655_350, sndbuf: 655_350, recbuf: 655_350]
     })
   end
 


### PR DESCRIPTION
ex_abci server's job is to receive tcp message from tendermint, decode and forward to forge's abci server to handle, and send the response back to tendermint. With larger tcp message from tendermint, it might cause ex_abci's server's tcp recbuf to be full, then tcp will tell tendermint to stop sending more data, thus may causing the pause on receiving the data. Here we tune the recv buffer to be 640k to see if this helps solve the issue in https://github.com/ArcBlock/forge/issues/669