### PR TITLE
Fix forge web reconnection issue

### DIFF
--- a/lib/forge_sdk/rpc/conn.ex
+++ b/lib/forge_sdk/rpc/conn.ex
@@ -22,10 +22,23 @@ defmodule ForgeSdk.Rpc.Conn do
   @spec close :: any()
   def close, do: Connection.call(__MODULE__, :close)
 
+  @spec child_spec(String.t()) :: map
   def child_spec(addr) do
     %{
       id: __MODULE__,
-      start: {__MODULE__, :start_link, [addr, []]},
+      start:
+        {__MODULE__, :start_link,
+         [
+           addr,
+           [
+             adapter_opts: %{
+               # turn off keepalive to prevent zombie connections for grpc server
+               http2_opts: %{keepalive: :infinity},
+               # disable retry on gun's part to prevent undesired zombie connections
+               retry: 0
+             }
+           ]
+         ]},
       type: :worker,
       restart: :permanent,
       shutdown: 500
@@ -39,11 +52,11 @@ defmodule ForgeSdk.Rpc.Conn do
   def init({"tcp://" <> addr, opts}), do: {:connect, :init, %{addr: addr, opts: opts, chan: nil}}
 
   def connect(_, %{chan: nil, addr: addr, opts: opts} = state) do
-    Logger.info("Forge ABI RPC: reconnect to #{addr}")
+    Logger.info("Forge ABI RPC: reconnect to #{addr}...")
 
     case Client.connect(addr, opts) do
       {:ok, chan} -> {:ok, %{state | chan: chan}}
-      {:error, _} -> {:backoff, 500, state}
+      {:error, _} -> {:backoff, 5000, state}
     end
   end
 

--- a/lib/forge_sdk/rpc/conn.ex
+++ b/lib/forge_sdk/rpc/conn.ex
@@ -12,11 +12,9 @@ defmodule ForgeSdk.Rpc.Conn do
     Connection.start_link(__MODULE__, {addr, opts}, name: __MODULE__)
   end
 
+  @spec get_chan() :: GRPC.Channel.t() | {:error, :closed}
   def get_chan do
-    case Process.whereis(ForgeSdk.Rpc.Conn) do
-      nil -> nil
-      _ -> Connection.call(__MODULE__, :get_chan)
-    end
+    Connection.call(__MODULE__, :get_chan)
   end
 
   @spec close :: any()

--- a/lib/forge_sdk/util.ex
+++ b/lib/forge_sdk/util.ex
@@ -44,8 +44,12 @@ defmodule ForgeSdk.Util do
     |> get_servers()
   end
 
+  @doc """
+  Get the gRPC connection channel.
+  """
+  @spec get_chan() :: GRPC.Channel.t() | {:error, any}
   def get_chan do
-    case ForgeSdk.Rpc.Conn.get_chan() do
+    case Process.whereis(ForgeSdk.Rpc.Conn) do
       nil ->
         config = ForgeSdk.get_env(:forge_config)
 
@@ -56,11 +60,10 @@ defmodule ForgeSdk.Util do
             v -> v
           end
 
-        {:ok, chan} = GRPC.Stub.connect(addr)
-        chan
+        GRPC.Stub.connect(addr)
 
-      v ->
-        v
+      _pid ->
+        ForgeSdk.Rpc.Conn.get_chan()
     end
   end
 


### PR DESCRIPTION
This PR shall fix issue https://github.com/ArcBlock/forge/issues/819

gun baked in an auto retry logic in itself, however the grpc library we are using is kinda ignore the retry logic. So it will create duplicate connections when we reconnect on our end while gun trying to retry by itself. And also it creates problem when the grpc server is dead. The gun process will retry 5 times every 5 seconds, then it will die, without anyone notice. That will cause the following grpc call fail due to there's no gun http2 client.

Since gun's process is wrapped inside grpc's channel struct, it's not possible for us to interact with the gun process when it's not connect successfully(we don't have the pid of the gun's process, we only got a {:error, reason} back). The solution here is to disable gun's retry completely and use Connection library's retry logic.

Also, we disable gun's keepalive feature, which is send ping frame to server every 5 seconds. Because this will create immortal http2 connection with server, when someone is creating a lot of gun's h2 connection, mainly unintentionally. 