### PR TITLE
:bug: fix create asset factory example error

### DIFF
--- a/lib/forge_sdk.ex
+++ b/lib/forge_sdk.ex
@@ -75,7 +75,7 @@ defmodule ForgeSdk do
       w = ForgeSdk.create_wallet()
       ForgeSdk.declare(ForgeAbi.DeclareTx.new(moniker: "theater"), wallet: w)
       w1 = ForgeSdk.create_wallet()
-      ForgeSdk.declare(ForgeAbi.DeclareTx.new(moniker: "tyr"), wallet: w)
+      ForgeSdk.declare(ForgeAbi.DeclareTx.new(moniker: "tyr"), wallet: w1)
 
       # Note application shall already registered `Ticket` into Forge via `deploy_protocol`.
       factory = %{


### PR DESCRIPTION
note: the elixir example is not clear for white user. and the js example is better.

js example refer https://github.com/ArcBlock/forge-js/blob/master/examples/protocol/asset_factory.js
